### PR TITLE
Put entire core processing into a thread

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -122,7 +122,7 @@ pub struct CoreHandle {
 }
 
 pub fn create_handles() -> (UIHandle, CoreHandle) {
-    let (ui_to_core_tx, core_from_ui_rx) = mpsc::channel::<UICoreMsg>(1);
+    let (ui_to_core_tx, core_from_ui_rx) = mpsc::channel::<UICoreMsg>(50);
 
     let ui_handle = UIHandle { ui_to_core_tx };
 


### PR DESCRIPTION
I thought this would be a good idea to seperate the subscription thread stuff from core processing, but when I removed the thread spawn around the db unlock part, it did not actually fix the issue we had previously ran into. I think that's just because the thread it's in is still being bottlenecked, but it makes me question whether the whole subscription part is already in a thread anyways and I'm spinning up a new thread here unnecessarily. 

I think making mpsc channel 50 is better anyways so I'll break that out into a new commit. 

Was just thinking about threading earlier today and whether this would help, figured I'd get a second opinion and we can close it if it's pointless. 

Thoughts? 