### PR TITLE
fix: add wayland and libxkbcommon to LD_LIBRARY_PATH

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
           pkgs.xorg.libXi
           pkgs.xorg.libXrandr
           pkgs.diesel-cli
+          pkgs.wayland
         ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
           pkgs.darwin.apple_sdk.frameworks.AppKit 
           pkgs.darwin.apple_sdk.frameworks.CoreText
@@ -61,7 +62,7 @@
           packages = inputs;
           shellHook = ''
             export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
-            export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH
+            export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH:${pkgs.wayland}/lib:${pkgs.libxkbcommon}/lib
           '';
         };
       }


### PR DESCRIPTION
Running Ubuntu 22.04 and encountered:
```
thread 'main' panicked at /home/ethan/.cargo/git/checkouts/iced-f01cba4d5e61fd0a/b30d34f/winit/src/application.rs:153:10:
Create event loop: Os(OsError { line: 81, file: "/home/ethan/.cargo/git/checkouts/winit-57d3141eaf559308/8affa52/src/platform_impl/linux/wayland/event_loop/mod.rs", error: WaylandError(Connection(NoWaylandLib)) })
```
This resolves it but I now encounter:
```
└─▪ just run
RUST_LOG=harbor=debug,iced_wgpu=error,wgpu_core=error,info cargo run 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
     Running `target/debug/harbor`
 WARN  sctk_adwaita::buttons > Ignoring unknown button type: 
thread 'main' panicked at /home/ethan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-core-0.19.4/src/instance.rs:521:39:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Putting into draft PR and will attempt more iterations in the future.