### PR TITLE
Skip screens

### DIFF
--- a/harbor-ui/src/components/button.rs
+++ b/harbor-ui/src/components/button.rs
@@ -22,12 +22,13 @@ pub fn h_button(text_str: &str, icon: SvgIcon, loading: bool) -> Button<'_, Mess
     };
 
     Button::new(center(content))
-        .style(|theme, status| {
+        .style(move |theme, status| {
             let gray = lighten(theme.palette().background, 0.5);
 
-            let border_color = match status {
-                Status::Disabled => gray,
-                _ => Color::WHITE,
+            let border_color = if loading || matches!(status, Status::Disabled) {
+                gray
+            } else {
+                Color::WHITE
             };
 
             let border = Border {
@@ -36,16 +37,17 @@ pub fn h_button(text_str: &str, icon: SvgIcon, loading: bool) -> Button<'_, Mess
                 radius: (8.).into(),
             };
 
-            let background = match status {
-                Status::Hovered => lighten(theme.palette().background, 0.1),
-                Status::Pressed => darken(Color::BLACK, 0.1),
-                _ => theme.palette().background,
+            let background = if loading {
+                theme.palette().background
+            } else {
+                match status {
+                    Status::Hovered => lighten(theme.palette().background, 0.1),
+                    Status::Pressed => darken(Color::BLACK, 0.1),
+                    _ => theme.palette().background,
+                }
             };
 
-            let text_color = match status {
-                Status::Disabled => gray,
-                _ => Color::WHITE,
-            };
+            let text_color = if loading { gray } else { Color::WHITE };
 
             button::Style {
                 background: Some(background.into()),

--- a/harbor-ui/src/components/toast.rs
+++ b/harbor-ui/src/components/toast.rs
@@ -93,14 +93,10 @@ impl<'a> ToastManager<'a> {
                     .width(Length::Fixed(24.))
                     .height(Length::Fixed(24.));
 
-                let body = if let Some(body) = toast.body.clone() {
-                    Some(text(body))
-                } else {
-                    None
-                };
+                let body = toast.body.clone().map(text);
 
-                container(column![container(column![
-                    row![
+                container(column![container(
+                    column![row![
                         text(toast.title.as_str()).font(Font {
                             family: iced::font::Family::default(),
                             weight: iced::font::Weight::Bold,
@@ -110,10 +106,9 @@ impl<'a> ToastManager<'a> {
                         horizontal_space(),
                         close_button.on_press((on_close)(index))
                     ]
-                    .align_y(Alignment::Center),
-                ]
-                .push_maybe(body)
-            )
+                    .align_y(Alignment::Center),]
+                    .push_maybe(body)
+                )
                 .width(Length::Fill)
                 .padding(16)
                 .style(match toast.status {

--- a/harbor-ui/src/components/toast.rs
+++ b/harbor-ui/src/components/toast.rs
@@ -46,7 +46,7 @@ impl fmt::Display for ToastStatus {
 #[derive(Debug, Clone, Default)]
 pub struct Toast {
     pub title: String,
-    pub body: String,
+    pub body: Option<String>,
     pub status: ToastStatus,
 }
 
@@ -93,7 +93,11 @@ impl<'a> ToastManager<'a> {
                     .width(Length::Fixed(24.))
                     .height(Length::Fixed(24.));
 
-                // close_button.on_press(on_close(index));
+                let body = if let Some(body) = toast.body.clone() {
+                    Some(text(body))
+                } else {
+                    None
+                };
 
                 container(column![container(column![
                     row![
@@ -107,8 +111,9 @@ impl<'a> ToastManager<'a> {
                         close_button.on_press((on_close)(index))
                     ]
                     .align_y(Alignment::Center),
-                    text(toast.body.as_str())
-                ])
+                ]
+                .push_maybe(body)
+            )
                 .width(Length::Fill)
                 .padding(16)
                 .style(match toast.status {

--- a/harbor-ui/src/main.rs
+++ b/harbor-ui/src/main.rs
@@ -415,7 +415,13 @@ impl HarborWallet {
                     } else {
                         error!("Invalid invoice or address");
                         self.current_send_id = None;
-                        Task::none()
+                        Task::perform(async {}, |_| {
+                            Message::AddToast(Toast {
+                                title: "Failed to send".to_string(),
+                                body: Some("Invalid invoice or address".to_string()),
+                                status: ToastStatus::Bad,
+                            })
+                        })
                     }
                 }
             },
@@ -522,7 +528,7 @@ impl HarborWallet {
                     Task::perform(async {}, move |_| {
                         Message::AddToast(Toast {
                             title: "Failed to join mint".to_string(),
-                            body: "Invalid invite code".to_string(),
+                            body: Some("Invalid invite code".to_string()),
                             status: ToastStatus::Bad,
                         })
                     })
@@ -538,7 +544,7 @@ impl HarborWallet {
                     Task::perform(async {}, |_| {
                         Message::AddToast(Toast {
                             title: "Failed to preview mint".to_string(),
-                            body: "Invalid invite code".to_string(),
+                            body: Some("Invalid invite code".to_string()),
                             status: ToastStatus::Bad,
                         })
                     })
@@ -562,7 +568,7 @@ impl HarborWallet {
                 Task::perform(async {}, |_| {
                     Message::AddToast(Toast {
                         title: "Copied to clipboard".to_string(),
-                        body: "...".to_string(),
+                        body: None,
                         status: ToastStatus::Neutral,
                     })
                 }),
@@ -618,7 +624,18 @@ impl HarborWallet {
                     if self.current_receive_id == msg.id {
                         self.receive_success_msg = Some(params);
                         self.current_receive_id = None;
+
+                        // Navigate to the history screen
+                        self.active_route = Route::History;
                     }
+                    // Toast success
+                    // Task::perform(async {}, |_| {
+                    //     Message::AddToast(Toast {
+                    //         title: "Payment received".to_string(),
+                    //         body: None,
+                    //         status: ToastStatus::Good,
+                    //     })
+                    // })
                     Task::none()
                 }
                 CoreUIMsg::ReceiveFailed(reason) => {
@@ -660,7 +677,7 @@ impl HarborWallet {
                     Task::perform(async {}, move |_| {
                         Message::AddToast(Toast {
                             title: "Failed to join mint".to_string(),
-                            body: reason.clone(),
+                            body: Some(reason.clone()),
                             status: ToastStatus::Bad,
                         })
                     })
@@ -671,7 +688,7 @@ impl HarborWallet {
                     Task::perform(async {}, move |_| {
                         Message::AddToast(Toast {
                             title: "Failed to remove mint".to_string(),
-                            body: reason.clone(),
+                            body: Some(reason.clone()),
                             status: ToastStatus::Bad,
                         })
                     })
@@ -716,8 +733,7 @@ impl HarborWallet {
                     Task::perform(async {}, |_| {
                         Message::AddToast(Toast {
                             title: "Mint added".to_string(),
-                            // TODO: maybe we should make body optional
-                            body: "...".to_string(),
+                            body: None,
                             status: ToastStatus::Neutral,
                         })
                     })
@@ -729,8 +745,7 @@ impl HarborWallet {
                     Task::perform(async {}, |_| {
                         Message::AddToast(Toast {
                             title: "Mint removed".to_string(),
-                            // TODO: maybe we should make body optional
-                            body: "...".to_string(),
+                            body: None,
                             status: ToastStatus::Neutral,
                         })
                     })

--- a/harbor-ui/src/routes/mints.rs
+++ b/harbor-ui/src/routes/mints.rs
@@ -1,4 +1,4 @@
-use iced::widget::{column, text};
+use iced::widget::column;
 use iced::Element;
 
 use crate::components::{
@@ -8,29 +8,26 @@ use crate::{AddFederationStatus, HarborWallet, Message, PeekStatus};
 
 use super::{MintSubroute, Route};
 
+// Expects to always have at least one federation, otherwise we should be on the add mint screen
 fn mints_list(harbor: &HarborWallet) -> Element<Message> {
     let header = h_header("Mints", "Manage your mints here.");
 
-    let list = if harbor.federation_list.is_empty() {
-        column![text("No federations added yet.").size(18)]
-    } else {
-        let active_federation = harbor
-            .active_federation
-            .as_ref()
-            .expect("No active federation");
+    let active_federation = harbor
+        .active_federation
+        .as_ref()
+        .expect("No active federation");
 
-        harbor
-            .federation_list
-            .iter()
-            .fold(column![], |column, item| {
-                column.push(h_federation_item(
-                    item,
-                    item.id != active_federation.id,
-                    true,
-                ))
-            })
-            .spacing(48)
-    };
+    let list = harbor
+        .federation_list
+        .iter()
+        .fold(column![], |column, item| {
+            column.push(h_federation_item(
+                item,
+                item.id != active_federation.id,
+                true,
+            ))
+        })
+        .spacing(48);
 
     let add_mint_button = h_button("Add Mint", SvgIcon::Plus, false)
         .on_press(Message::Navigate(Route::Mints(MintSubroute::Add)));
@@ -90,8 +87,12 @@ fn mints_add(harbor: &HarborWallet) -> Element<Message> {
 }
 
 pub fn mints(harbor: &HarborWallet) -> Element<Message> {
-    match harbor.active_route {
-        Route::Mints(MintSubroute::Add) => mints_add(harbor),
-        _ => mints_list(harbor),
+    if harbor.federation_list.is_empty() {
+        mints_add(harbor)
+    } else {
+        match harbor.active_route {
+            Route::Mints(MintSubroute::Add) => mints_add(harbor),
+            _ => mints_list(harbor),
+        }
     }
 }

--- a/harbor-ui/src/routes/receive.rs
+++ b/harbor-ui/src/routes/receive.rs
@@ -1,6 +1,5 @@
 use crate::components::{
-    basic_layout, h_button, h_caption_text, h_header, h_input, h_screen_header,
-    InputArgs, SvgIcon,
+    basic_layout, h_button, h_caption_text, h_header, h_input, h_screen_header, InputArgs, SvgIcon,
 };
 use crate::{HarborWallet, Message, ReceiveMethod, ReceiveStatus};
 use iced::widget::container::Style;
@@ -18,9 +17,8 @@ pub fn receive(harbor: &HarborWallet) -> Element<Message> {
     let reset_button =
         h_button("Start over", SvgIcon::Restart, false).on_press(Message::ReceiveStateReset);
 
-    let column = match (&harbor.receive_success_msg, receive_string) {
-        // Starting state
-        (None, None) => {
+    let column = match receive_string {
+        None => {
             let header = if !harbor.onchain_receive_enabled {
                 h_header("Deposit", "Receive via lightning.")
             } else {
@@ -85,7 +83,7 @@ pub fn receive(harbor: &HarborWallet) -> Element<Message> {
             }
         }
         // We've generated an invoice or address
-        (None, Some(receive_string)) => {
+        Some(receive_string) => {
             let header = h_header("Receive", "Scan this QR or copy the string.");
 
             let data = harbor.receive_qr_data.as_ref().unwrap();
@@ -117,10 +115,6 @@ pub fn receive(harbor: &HarborWallet) -> Element<Message> {
                     .on_press(Message::CopyToClipboard(receive_string)),
                 reset_button
             ]
-        }
-        // Success states aren't rendered here, we jump to the history screen
-        _ => {
-            panic!("Success states aren't rendered here, you should be on the history screen right now!")
         }
     };
 

--- a/harbor-ui/src/routes/receive.rs
+++ b/harbor-ui/src/routes/receive.rs
@@ -1,11 +1,10 @@
 use crate::components::{
-    basic_layout, h_button, h_caption_text, h_header, h_input, h_screen_header, mini_copy,
+    basic_layout, h_button, h_caption_text, h_header, h_input, h_screen_header,
     InputArgs, SvgIcon,
 };
 use crate::{HarborWallet, Message, ReceiveMethod, ReceiveStatus};
-use harbor_client::ReceiveSuccessMsg;
 use iced::widget::container::Style;
-use iced::widget::{column, container, qr_code, radio, row, text};
+use iced::widget::{column, container, qr_code, radio, text};
 use iced::Color;
 use iced::{Border, Element, Font};
 
@@ -18,20 +17,6 @@ pub fn receive(harbor: &HarborWallet) -> Element<Message> {
 
     let reset_button =
         h_button("Start over", SvgIcon::Restart, false).on_press(Message::ReceiveStateReset);
-
-    let bold_font = Font {
-        family: iced::font::Family::Monospace,
-        weight: iced::font::Weight::Bold,
-        stretch: iced::font::Stretch::Normal,
-        style: iced::font::Style::Normal,
-    };
-
-    let mono_font = Font {
-        family: iced::font::Family::Monospace,
-        weight: iced::font::Weight::Normal,
-        stretch: iced::font::Stretch::Normal,
-        style: iced::font::Style::Normal,
-    };
 
     let column = match (&harbor.receive_success_msg, receive_string) {
         // Starting state
@@ -133,38 +118,9 @@ pub fn receive(harbor: &HarborWallet) -> Element<Message> {
                 reset_button
             ]
         }
-        // Success states
-        (Some(ReceiveSuccessMsg::Lightning), _) => {
-            let header = h_header("Got it", "Payment received");
-
-            // TODO: should have some info here we can show like amount, fee, etc.
-
-            column![header, reset_button]
-        }
-        (Some(ReceiveSuccessMsg::Onchain { txid }), _) => {
-            let txid_str = txid.to_string();
-            let header = h_header("Got it", "Payment received");
-
-            let txid_str_shortened = if txid_str.len() > 20 {
-                // get the first 10 and last 10 chars
-                let txid_str_start = &txid_str[0..10];
-                let txid_str_end = &txid_str[txid_str.len() - 10..];
-
-                // add ellipsis
-                format!("{txid_str_start}...{txid_str_end}")
-            } else {
-                txid_str.clone()
-            };
-
-            let txid = row![
-                text("txid").font(bold_font),
-                text(txid_str_shortened).font(mono_font),
-                mini_copy(txid_str)
-            ]
-            .align_y(iced::Alignment::Center)
-            .spacing(8);
-
-            column![header, txid, reset_button]
+        // Success states aren't rendered here, we jump to the history screen
+        _ => {
+            panic!("Success states aren't rendered here, you should be on the history screen right now!")
         }
     };
 

--- a/harbor-ui/src/routes/send.rs
+++ b/harbor-ui/src/routes/send.rs
@@ -1,5 +1,4 @@
-use iced::widget::{column, text, Checkbox};
-use iced::Color;
+use iced::widget::{column, Checkbox};
 use iced::Element;
 
 use crate::components::{
@@ -36,29 +35,9 @@ pub fn send(harbor: &HarborWallet) -> Element<Message> {
     )
     .on_press(Message::Send(harbor.send_dest_input_str.clone()));
 
-    let failure_message = harbor
-        .send_failure_reason
-        .as_ref()
-        .map(|r| text(r).size(32).color(Color::from_rgb(255., 0., 0.)));
-
-    let success_message = harbor.send_success_msg.as_ref().map(|r| {
-        text(format!("Success: {r:?}"))
-            .size(32)
-            .color(Color::from_rgb(0., 255., 0.))
-    });
-
     let checkbox = Checkbox::new("Send Max", harbor.is_max).on_toggle(Message::SetIsMax);
 
-    let column = if let Some(failure_message) = failure_message {
-        let dangit_button =
-            h_button("Dangit", SvgIcon::Squirrel, false).on_press(Message::SendStateReset);
-        column![header, failure_message, dangit_button]
-    } else if let Some(success_message) = success_message {
-        let nice_button = h_button("Nice", SvgIcon::Heart, false).on_press(Message::SendStateReset);
-        column![header, success_message, nice_button]
-    } else {
-        column![header, amount_input, checkbox, dest_input, send_button]
-    };
+    let column = column![header, amount_input, checkbox, dest_input, send_button];
 
     column![
         h_screen_header(harbor, true),

--- a/harbor-ui/src/routes/settings.rs
+++ b/harbor-ui/src/routes/settings.rs
@@ -14,14 +14,14 @@ pub fn settings(harbor: &HarborWallet) -> Element<Message> {
     let add_good_toast_button =
         h_button("Nice!", SvgIcon::Plus, false).on_press(Message::AddToast(Toast {
             title: "Hello".to_string(),
-            body: "This is a toast".to_string(),
+            body: Some("This is a toast".to_string()),
             status: ToastStatus::Good,
         }));
 
     let add_error_toast_button =
         h_button("Error Toast", SvgIcon::Plus, false).on_press(Message::AddToast(Toast {
             title: "Error".to_string(),
-            body: "This is a toast".to_string(),
+            body: Some("This is a toast".to_string()),
             status: ToastStatus::Bad,
         }));
 


### PR DESCRIPTION
as discussed we're removing some of the intermediate states that weren't adding a lot of value:
- if there are no federations, go straight to add mint
- on send / receive success jump straight to history

In a followup I will add tx details to history, and we'll autoselect the tx item that matches the "success message" we got from the backend