### PR TITLE
fix balance updates by cloning less

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .env
 .direnv
 harbor.sqlite
+/prompts

--- a/harbor-ui/src/components/screen_header.rs
+++ b/harbor-ui/src/components/screen_header.rs
@@ -10,8 +10,8 @@ use super::{
 };
 
 pub fn h_screen_header(harbor: &HarborWallet, show_balance: bool) -> Element<Message> {
-    if let Some(item) = harbor.active_federation.as_ref() {
-        let FederationItem { name, balance, .. } = item;
+    if let Some(item) = harbor.active_federation() {
+        let FederationItem { name, .. } = item;
         let people_icon = map_icon(SvgIcon::People, 24., 24.);
 
         let federation_names: Vec<String> = harbor
@@ -43,7 +43,7 @@ pub fn h_screen_header(harbor: &HarborWallet, show_balance: bool) -> Element<Mes
             .spacing(16)
             .width(Length::Shrink)
             .padding(Padding::new(0.).left(16));
-        let formatted_balance = format_amount(*balance);
+        let formatted_balance = format_amount(item.balance);
 
         let balance = row![text(formatted_balance).size(24)]
             .align_y(Alignment::Center)

--- a/harbor-ui/src/components/sidebar.rs
+++ b/harbor-ui/src/components/sidebar.rs
@@ -11,7 +11,7 @@ use crate::{HarborWallet, Message, Route};
 use super::{harbor_logo, indicator, lighten, map_icon, sidebar_button};
 
 pub fn sidebar(harbor: &HarborWallet) -> Element<Message> {
-    let transfer_disabled = harbor.balance_sats() == 0 || harbor.federation_list.is_empty();
+    let transfer_disabled = harbor.total_balance_sats() == 0 || harbor.federation_list.is_empty();
     let transfer_button = sidebar_button(
         "Transfer",
         SvgIcon::LeftRight,

--- a/harbor-ui/src/routes/home.rs
+++ b/harbor-ui/src/routes/home.rs
@@ -7,18 +7,13 @@ use crate::{HarborWallet, Message};
 use super::Route;
 
 pub fn home(harbor: &HarborWallet) -> Element<Message> {
-    let formatted_balance = if let Some(federation) = &harbor.active_federation {
-        format_amount(federation.balance)
-    } else {
-        format_amount(0)
-    };
+    let formatted_balance = harbor
+        .active_federation()
+        .map_or_else(|| format_amount(0), |f| format_amount(f.balance));
 
     let balance = text(formatted_balance).size(64);
-    let send_disabled = harbor
-        .active_federation
-        .as_ref()
-        .map_or(true, |f| f.balance == 0);
-    let receive_disabled = harbor.active_federation.is_none();
+    let send_disabled = harbor.active_federation().map_or(true, |f| f.balance == 0);
+    let receive_disabled = harbor.active_federation().is_none();
     let send_button = h_button("Send", SvgIcon::UpRight, false);
     let receive_button = h_button("Deposit", SvgIcon::DownLeft, false);
 

--- a/harbor-ui/src/routes/mints.rs
+++ b/harbor-ui/src/routes/mints.rs
@@ -12,18 +12,13 @@ use super::{MintSubroute, Route};
 fn mints_list(harbor: &HarborWallet) -> Element<Message> {
     let header = h_header("Mints", "Manage your mints here.");
 
-    let active_federation = harbor
-        .active_federation
-        .as_ref()
-        .expect("No active federation");
-
     let list = harbor
         .federation_list
         .iter()
         .fold(column![], |column, item| {
             column.push(h_federation_item(
                 item,
-                item.id != active_federation.id,
+                item.id != harbor.active_federation_id.expect("No active federation"),
                 true,
             ))
         })


### PR DESCRIPTION
some views weren't showing the updated balance after send / receive. we were trying to keep synchronized state for this "federation_balances" thing, was simpler to just calculate it from the actual list of federations, fewer things to update when state changes