### PR TITLE
Fix timestamps on history events

### DIFF
--- a/harbor-client/src/db_models/lightning_payment.rs
+++ b/harbor-client/src/db_models/lightning_payment.rs
@@ -164,7 +164,7 @@ impl From<LightningPayment> for TransactionItem {
             txid: None,
             direction: TransactionDirection::Outgoing,
             federation_id: payment.fedimint_id(),
-            timestamp: payment.created_at.and_utc().timestamp() as u64,
+            timestamp: payment.updated_at.and_utc().timestamp() as u64,
         }
     }
 }

--- a/harbor-client/src/db_models/lightning_receive.rs
+++ b/harbor-client/src/db_models/lightning_receive.rs
@@ -161,7 +161,7 @@ impl From<LightningReceive> for TransactionItem {
             txid: None,
             direction: TransactionDirection::Incoming,
             federation_id: payment.fedimint_id(),
-            timestamp: payment.created_at.and_utc().timestamp() as u64,
+            timestamp: payment.updated_at.and_utc().timestamp() as u64,
         }
     }
 }

--- a/harbor-client/src/db_models/onchain_payment.rs
+++ b/harbor-client/src/db_models/onchain_payment.rs
@@ -143,7 +143,7 @@ impl From<OnChainPayment> for TransactionItem {
                 .map(|t| Txid::from_str(t).expect("invalid txid")),
             direction: TransactionDirection::Outgoing,
             federation_id: payment.fedimint_id(),
-            timestamp: payment.created_at.and_utc().timestamp() as u64,
+            timestamp: payment.updated_at.and_utc().timestamp() as u64,
         }
     }
 }

--- a/harbor-client/src/db_models/onchain_receive.rs
+++ b/harbor-client/src/db_models/onchain_receive.rs
@@ -159,7 +159,7 @@ impl From<OnChainReceive> for TransactionItem {
                 .map(|t| Txid::from_str(t).expect("invalid txid")),
             direction: TransactionDirection::Incoming,
             federation_id: payment.fedimint_id(),
-            timestamp: payment.created_at.and_utc().timestamp() as u64,
+            timestamp: payment.updated_at.and_utc().timestamp() as u64,
         }
     }
 }

--- a/harbor-ui/src/components/util.rs
+++ b/harbor-ui/src/components/util.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Local};
 use iced::Color;
 use palette::{rgb::Rgb, FromColor, Hsl};
 
@@ -35,7 +36,8 @@ fn from_hsl(hsl: Hsl) -> Color {
 
 pub fn format_timestamp(timestamp: &u64) -> String {
     let signed = timestamp.to_owned() as i64;
-    let date_time = chrono::DateTime::from_timestamp(signed, 0).unwrap();
+    let utc = DateTime::from_timestamp(signed, 0).unwrap();
+    let date_time: DateTime<Local> = DateTime::from(utc);
     format!("{}", date_time.format("%m/%d/%Y, %l:%M %P"))
 }
 


### PR DESCRIPTION
We were displaying the created time instead of last updated. Also we were displaying it in utc time, this fixes it to use the local timezone

Closes #132