### PR TITLE
try a different release strategy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,19 @@
 name: "Release"
 
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       tag:
-        description: "Specify tag to create"
+        description: 'Tag name (e.g. v1.0.0)'
         required: true
+        type: string
+
+# Add permissions block
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -19,71 +27,26 @@ jobs:
             package: bash scripts/package-macos.sh
     runs-on: ${{ matrix.target.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flake-checker-action@main
+      - uses: Swatinem/rust-cache@v2
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          env-vars: CARGO USE_VENDOR_FEATURE
 
       - name: Build
-        run: ${{ matrix.target.make }}
+        run: nix develop --command bash -c "${{ matrix.target.make }}"
 
       - name: Package DMG
-        run: ${{ matrix.target.package }}
+        run: nix develop --command bash -c "${{ matrix.target.package }}"
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - name: Create Release and Upload Assets
+        uses: softprops/action-gh-release@v2
         with:
-          name: ${{ matrix.target.target }}
-          path: target/release/macos/harbor.dmg
-
-  create-release:
-    needs: build
-    name: Create Release
-    outputs:
-      upload_url: ${{ steps.create-release.outputs.upload_url }}
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - name: Create Release
-        id: create-release
-        uses: actions/create-release@v1
-        with:
-          tag_name: ${{ github.event.inputs.tag }}
-          release_name: ${{ github.event.inputs.tag }}
+          name: Release ${{ github.event.inputs.tag || github.ref_name }}
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           draft: true
           prerelease: false
-
-  add-assets:
-    needs: create-release
-    name: Add Assets
-
-    strategy:
-      matrix:
-        target:
-          - artifact: macos
-            asset_type: application/x-apple-diskimage
-
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ matrix.target.artifact }}
-          path: ${{ matrix.target.artifact }}
-
-      - name: Upload asset
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./${{ matrix.target.artifact }}/harbor.dmg
-          asset_name: harbor.dmg
-          asset_content_type: ${{ matrix.target.asset_type }} 
+          generate_release_notes: true
+          files: target/release/macos/harbor.dmg 


### PR DESCRIPTION
no reason not to use nix stuff here. also the other one failed so wanted to try something else. something we can do in the future is pin to specific commit hashes of these release actions for better reproducibility maybe