### PR TITLE
Settings cleanup

### DIFF
--- a/harbor-ui/src/components/checkbox.rs
+++ b/harbor-ui/src/components/checkbox.rs
@@ -1,0 +1,27 @@
+use iced::widget::{checkbox, text, Column};
+use iced::{Element, Length};
+
+use super::{styles, very_subtle};
+
+pub fn h_checkbox<'a, Message: 'a + Clone>(
+    label: &'static str,
+    description: Option<&'static str>,
+    is_checked: bool,
+    on_toggle: impl Fn(bool) -> Message + 'a,
+) -> Element<'a, Message> {
+    let mut content = Column::new().spacing(8).width(Length::Fill);
+
+    let checkbox = checkbox(label, is_checked)
+        .on_toggle(on_toggle)
+        .size(24)
+        .text_size(24)
+        .style(styles::checkbox_style);
+
+    content = content.push(checkbox);
+
+    if let Some(desc) = description {
+        content = content.push(text(desc).style(very_subtle).size(14));
+    }
+
+    content.into()
+}

--- a/harbor-ui/src/components/mod.rs
+++ b/harbor-ui/src/components/mod.rs
@@ -68,3 +68,8 @@ pub use debug_stuff::*;
 
 mod operation_status;
 pub use operation_status::*;
+
+mod checkbox;
+pub use checkbox::h_checkbox;
+
+pub use button::h_button;

--- a/harbor-ui/src/components/styles.rs
+++ b/harbor-ui/src/components/styles.rs
@@ -1,6 +1,6 @@
 use iced::{
     overlay::menu,
-    widget::{container::Style as ContainerStyle, pick_list, text::Style},
+    widget::{checkbox, container::Style as ContainerStyle, pick_list, text::Style},
     Border, Color, Shadow, Theme,
 };
 
@@ -167,5 +167,26 @@ pub fn tag_style(theme: &Theme) -> ContainerStyle {
         background: Some(gray.into()),
         border,
         shadow: Shadow::default(),
+    }
+}
+
+pub fn checkbox_style(theme: &Theme, status: checkbox::Status) -> checkbox::Style {
+    let background = theme.palette().background;
+
+    let background = match status {
+        checkbox::Status::Hovered { is_checked: _ } => lighten(background, 0.1),
+        checkbox::Status::Active { is_checked: _ } => background,
+        checkbox::Status::Disabled { is_checked: _ } => background,
+    };
+
+    checkbox::Style {
+        icon_color: theme.palette().primary,
+        text_color: Some(Color::WHITE),
+        background: background.into(),
+        border: Border {
+            color: Color::WHITE,
+            width: 2.0,
+            radius: (8.0).into(),
+        },
     }
 }

--- a/harbor-ui/src/components/toast.rs
+++ b/harbor-ui/src/components/toast.rs
@@ -500,7 +500,7 @@ fn neutral(theme: &Theme) -> container::Style {
 
 fn good(theme: &Theme) -> container::Style {
     let gray = lighten(theme.palette().background, 0.1);
-    let green = Color::from_rgb8(40, 164, 127);
+    let green = theme.palette().success;
 
     styled(gray, green)
 }

--- a/harbor-ui/src/main.rs
+++ b/harbor-ui/src/main.rs
@@ -3,6 +3,7 @@ use crate::components::focus_input_id;
 use crate::components::{Toast, ToastManager, ToastStatus};
 use crate::config::{write_config, Config};
 use bitcoin::{Address, Network};
+use components::{MUTINY_GREEN, MUTINY_RED};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::invite_code::InviteCode;
@@ -853,6 +854,7 @@ impl HarborWallet {
             }
             Message::SetOnchainReceiveEnabled(enabled) => {
                 let (_, task) = self.send_from_ui(UICoreMsg::SetOnchainReceiveEnabled(enabled));
+                self.confirm_modal = None;
                 task
             }
             Message::SetTorEnabled(enabled) => {
@@ -1234,15 +1236,14 @@ impl HarborWallet {
     }
 
     fn theme(&self) -> iced::Theme {
-        let mutiny_red = Color::from_rgb8(250, 0, 80);
         iced::Theme::custom(
             String::from("Custom"),
             iced::theme::Palette {
                 background: Color::from_rgb8(23, 23, 25),
-                primary: mutiny_red,
+                primary: MUTINY_RED,
                 text: Color::WHITE,
-                success: Color::WHITE,
-                danger: mutiny_red,
+                success: MUTINY_GREEN,
+                danger: MUTINY_RED,
             },
         )
     }

--- a/harbor-ui/src/routes/send.rs
+++ b/harbor-ui/src/routes/send.rs
@@ -1,9 +1,9 @@
-use iced::widget::{column, Checkbox};
+use iced::widget::column;
 use iced::Element;
 
 use crate::components::{
-    basic_layout, h_button, h_header, h_input, h_screen_header, operation_status_for_id, InputArgs,
-    SvgIcon,
+    basic_layout, h_button, h_checkbox, h_header, h_input, h_screen_header,
+    operation_status_for_id, InputArgs, SvgIcon,
 };
 use crate::{HarborWallet, Message, SendStatus};
 
@@ -37,7 +37,7 @@ pub fn send(harbor: &HarborWallet) -> Element<Message> {
     )
     .on_press(Message::Send(harbor.send_dest_input_str.clone()));
 
-    let checkbox = Checkbox::new("Send Max", harbor.is_max).on_toggle(Message::SetIsMax);
+    let checkbox = h_checkbox("Send Max", None, harbor.is_max, Message::SetIsMax);
 
     let mut button_and_status = column![send_button];
 


### PR DESCRIPTION
<img width="1136" alt="Screenshot 2025-02-07 at 1 42 55 PM" src="https://github.com/user-attachments/assets/d7ff315a-2dde-45e0-820d-8399e8858616" />

closes #144 

we can probably do more... would like the seed words to be in a modal... but this is a lot better at least