### PR TITLE
feat: add LNv2 to Harbor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,6 +2500,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "fedimint-lnv2-client"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c0f2bd24070d94e484d20e60890a3197c228b734ffaba0c08fff5cc1f91d32b"
+dependencies = [
+ "anyhow",
+ "aquamarine",
+ "async-stream",
+ "async-trait",
+ "bitcoin",
+ "erased-serde",
+ "fedimint-api-client",
+ "fedimint-client",
+ "fedimint-core",
+ "fedimint-lnv2-common",
+ "fedimint-logging",
+ "fedimint-tpe",
+ "futures",
+ "itertools 0.13.0",
+ "lightning-invoice",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "fedimint-lnv2-common"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f6ca85ca7aa1e58b91362b6d6dd278420d60132e9362e4a989b9cce7bfb4fa0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitcoin",
+ "fedimint-core",
+ "fedimint-ln-common",
+ "fedimint-tpe",
+ "group",
+ "lightning-invoice",
+ "rand 0.8.5",
+ "reqwest 0.12.12",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+]
+
+[[package]]
 name = "fedimint-logging"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,6 +2700,22 @@ dependencies = [
  "tor-proto",
  "tor-rtcompat",
  "tracing",
+]
+
+[[package]]
+name = "fedimint-tpe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f62a76c9943873d952ca37914812d293a4f8d95eb962afc47d992fcc403d361"
+dependencies = [
+ "bitcoin_hashes 0.14.0",
+ "bls12_381",
+ "fedimint-core",
+ "group",
+ "rand 0.8.5",
+ "rand_chacha",
+ "serde",
+ "serde-big-array",
 ]
 
 [[package]]
@@ -3328,6 +3394,8 @@ dependencies = [
  "fedimint-core",
  "fedimint-ln-client",
  "fedimint-ln-common",
+ "fedimint-lnv2-client",
+ "fedimint-lnv2-common",
  "fedimint-mint-client",
  "fedimint-wallet-client",
  "futures",

--- a/harbor-client/Cargo.toml
+++ b/harbor-client/Cargo.toml
@@ -38,6 +38,8 @@ fedimint-mint-client = "0.6.1"
 fedimint-ln-client = "0.6.1"
 fedimint-bip39 = "0.6.1"
 fedimint-ln-common = "0.6.1"
+fedimint-lnv2-common = "0.6.1"
+fedimint-lnv2-client = "0.6.1"
 
 # BEGIN BLOCK OF KEEP IN SYNC WITH FEDIMINT'S VERSION
 arti-client = { version = "0.20.0", default-features = false, features = ["tokio", "rustls"], package = "fedimint-arti-client" }


### PR DESCRIPTION
With the upcoming Fedimint v0.7 release, new federations will spawn with the LNv2 module enabled by default (LNv1 will also be available).
https://github.com/fedimint/fedimint/pull/7034

This PR adds LNv2 support to Harbor. For generating an invoice and paying an invoice, it will first try LNv2 and if that fails, it will default back to using LNv1 (so that no functionality regresses).

LNv2 might fail for the following reasons:
1) Federation does not support the new module yet (i.e federations deployed before v0.7)
2) There are no registered LNv2 gateways
3) Lightning path finding error or other lightning error

For all of these cases, as this PR is implemented Harbor will re-try using LNv1.

Here is how I tested:

1) On same dev box, spawn regtest fedimint using latest master: `just mprocs`
2) Add LNv2 gateway:
```
gateway-ldk info
```
Using `api` from output. Only one registration is necessary, but I registered the gateway with all guardians.
```
fedimint-cli --our-id 0 --password pass module lnv2 gateways add http://127.0.0.1:18115/v1
fedimint-cli --our-id 1 --password pass module lnv2 gateways add http://127.0.0.1:18115/v1
fedimint-cli --our-id 2 --password pass module lnv2 gateways add http://127.0.0.1:18115/v1
fedimint-cli --our-id 3 --password pass module lnv2 gateways add http://127.0.0.1:18115/v1
```
3) Build and boot Harbor, turn Tor off.
4) Join federation (can get invite code using `fedimint-cli invite-code 0`
5) Generate invoice using Harbor, verify in Harbor logs that it used LNv2
6) Pay invoice using LND that spawned in devimint environment
`lncli payinvoice <invoice>`
7) Generate invoice using LNCLI, pay using Harbor, verify in Harbor logs that it used LNv2
`lncli addinvoice --amt_msat 200000`

All of the above worked for me. I also tested when the federation did not have LNv2 activated (by doing `export FM_ENABLE_MODULE_LNV2=0` before `just mprocs`) and everything also worked as expected, falling back to LNv1.

I also tested when LNv2 was activating, but no gateways were registered (skipping step 2). This also worked by falling back to LNv1.

Only weird thing currently is that LNv2 does not expose the preimage when a payment is successful like LNv1 did. I opened a PR to add this: https://github.com/fedimint/fedimint/pull/7064

Let me know if there's any questions!