### PR TITLE
chore: add LNv2 feature flag, default off

### DIFF
--- a/harbor-client/Cargo.toml
+++ b/harbor-client/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [features]
 default = []
 vendored = ["rusqlite/bundled-sqlcipher-vendored-openssl"]
+lnv2 = []
 
 [dependencies]
 anyhow = "1.0.89"

--- a/harbor-client/src/lib.rs
+++ b/harbor-client/src/lib.rs
@@ -405,6 +405,11 @@ impl HarborCore {
         msg_id: Uuid,
         invoice: Bolt11Invoice,
     ) -> anyhow::Result<OperationId> {
+        let enable_lnv2 = cfg!(feature = "lnv2");
+        if !enable_lnv2 {
+            return Err(anyhow::anyhow!("LNv2 is not enabled"));
+        }
+
         log::info!("Trying to pay {invoice} with LNv2...");
         let lnv2_module =
             client.get_first_module::<fedimint_lnv2_client::LightningClientModule>()?;
@@ -604,6 +609,11 @@ impl HarborCore {
         msg_id: Uuid,
         amount: Amount,
     ) -> anyhow::Result<(Bolt11Invoice, OperationId)> {
+        let enable_lnv2 = cfg!(feature = "lnv2");
+        if !enable_lnv2 {
+            return Err(anyhow::anyhow!("LNv2 is not enabled"));
+        }
+
         log::info!("Trying to pay receive {amount} with LNv2...");
         let lnv2_module =
             client.get_first_module::<fedimint_lnv2_client::LightningClientModule>()?;


### PR DESCRIPTION
Unfortunately, we are planning on merging one additional LNv2 change that is backwards incompatible: https://github.com/fedimint/fedimint/pull/7078

This will make v0.6.1 LNv2 libraries incompatible with v0.7.0. To protect against this, I added a feature flag to enable/disable LNv2, with it defaulted to off.

Once v0.7.0 is out, enabling LNv2 will be as simple as turning the feature on by default.