### PR TITLE
Cleanup deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3628,14 +3628,9 @@ dependencies = [
 name = "harbor-ui"
 version = "1.0.0-beta.rc1"
 dependencies = [
- "bip39",
- "bitcoin",
- "cdk",
- "cdk-redb",
+ "anyhow",
  "chrono",
  "fd-lock",
- "fedimint-core",
- "fedimint-ln-common",
  "harbor-client",
  "iced",
  "keyring-lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ members = [
 ]
 
 [workspace.dependencies]
-cdk = { version = "0.8.1", default-features = false, features = ["wallet"] }
-cdk-redb = { version = "0.8.1", default-features = false, features = ["wallet"] }
+anyhow = "1.0.89"
+chrono = "0.4.38"
+log = "0.4"
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = "1.0.138"
+tokio = { version = "1", features = ["full"] }
 uuid = { version = "1.12", features = ["v4"] }

--- a/harbor-client/Cargo.toml
+++ b/harbor-client/Cargo.toml
@@ -9,12 +9,12 @@ vendored = ["rusqlite/bundled-sqlcipher-vendored-openssl"]
 lnv2 = []
 
 [dependencies]
-anyhow = "1.0.89"
-log = "0.4"
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1.0.210", features = ["derive"] }
-serde_json = "1.0.138"
-chrono = "0.4.38"
+anyhow = { workspace = true }
+log = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
 rusqlite = { version = "0.28.0", features = ["sqlcipher"] }
 diesel = { version = "2.1.6", features = ["sqlite", "chrono", "r2d2"] }
 diesel_migrations = { version = "2.1.0", features = ["sqlite"] }
@@ -28,8 +28,8 @@ once_cell = "1.20.2"
 httparse = "1.8.0"
 url = "2.5.0"
 
-cdk = { workspace = true }
-cdk-redb = { workspace = true }
+cdk = { version = "0.8.1", default-features = false, features = ["wallet"] }
+cdk-redb = { version = "0.8.1", default-features = false, features = ["wallet"] }
 
 bitcoin = { version = "0.32.4", features = ["base64"] }
 bip39 = "2.0.0"

--- a/harbor-client/src/lib.rs
+++ b/harbor-client/src/lib.rs
@@ -26,7 +26,7 @@ use fedimint_core::core::{ModuleKind, OperationId};
 use fedimint_core::invite_code::InviteCode;
 use fedimint_ln_client::{LightningClientModule, PayType};
 use fedimint_ln_common::config::FeeToAmount;
-use fedimint_ln_common::lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description};
+use fedimint_ln_common::lightning_invoice::{Bolt11InvoiceDescription, Description};
 use fedimint_wallet_client::WalletClientModule;
 use futures::{SinkExt, channel::mpsc::Sender};
 use lightning_address::make_lnurl_request;
@@ -71,6 +71,14 @@ pub mod fedimint_client;
 mod http;
 pub mod lightning_address;
 pub mod metadata;
+
+pub use bip39;
+pub use bitcoin;
+pub use cdk;
+pub use cdk_redb;
+pub use fedimint_core;
+
+pub use fedimint_ln_common::lightning_invoice::Bolt11Invoice;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum MintIdentifier {

--- a/harbor-ui/Cargo.toml
+++ b/harbor-ui/Cargo.toml
@@ -8,25 +8,20 @@ default = []
 vendored = ["harbor-client/vendored"]
 
 [dependencies]
+anyhow = { workspace = true }
 harbor-client = { version = "1.0.0-beta.rc1", path = "../harbor-client" }
 fd-lock = "4.0.2"
 
-log = "0.4"
+log = { workspace = true }
 simplelog = "0.12"
 iced = { git = "https://github.com/iced-rs/iced", rev = "940a079", features = ["debug", "tokio", "svg", "qr_code", "advanced"] }
 lyon_algorithms = "1.0"
-tokio = { version = "1", features = ["full"] }
+tokio = { workspace = true }
 palette = "0.7"
-chrono = "0.4.38"
+chrono = { workspace = true }
 uuid = { workspace = true }
-cdk = { workspace = true }
-cdk-redb = { workspace = true }
 
-bitcoin = { version = "0.32.4", features = ["base64"] }
-bip39 = "2.0.0"
-fedimint-core = "0.6.1"
-fedimint-ln-common = "0.6.1"
 opener = { version = "0.7.2", features = ["reveal"] }
-serde = { version = "1.0.217", features = ["derive"] }
-serde_json = "1.0.138"
+serde = { workspace = true }
+serde_json = { workspace = true }
 keyring-lib = "1.0.2"

--- a/harbor-ui/src/bridge.rs
+++ b/harbor-ui/src/bridge.rs
@@ -1,15 +1,15 @@
 use crate::Message;
 use crate::config::read_config;
 use crate::keyring::{save_to_keyring, try_get_keyring_password};
-use bitcoin::Network;
-use cdk::mint_url::MintUrl;
-use cdk::nuts::CurrencyUnit;
-use cdk::wallet::WalletBuilder;
-use cdk_redb::WalletRedbDatabase;
-use fedimint_core::config::FederationId;
+use harbor_client::bitcoin::Network;
 use harbor_client::cashu_client::TorMintConnector;
+use harbor_client::cdk::mint_url::MintUrl;
+use harbor_client::cdk::nuts::CurrencyUnit;
+use harbor_client::cdk::wallet::WalletBuilder;
+use harbor_client::cdk_redb::WalletRedbDatabase;
 use harbor_client::db::{DBConnection, check_password, setup_db};
 use harbor_client::fedimint_client::{FederationInviteOrId, FedimintClient};
+use harbor_client::fedimint_core::config::FederationId;
 use harbor_client::metadata::FederationMeta;
 use harbor_client::{
     CoreUIMsg, CoreUIMsgPacket, HarborCore, MintIdentifier, UICoreMsg, UICoreMsgPacket, data_dir,

--- a/harbor-ui/src/components/transaction_details.rs
+++ b/harbor-ui/src/components/transaction_details.rs
@@ -1,12 +1,12 @@
 use super::{format_amount, format_timestamp, side_panel_style, subtitle};
 use crate::Message;
 use crate::components::{SvgIcon, map_icon, text_link};
-use bitcoin::Network;
-use fedimint_core::config::FederationId;
+use harbor_client::bitcoin::Network;
 use harbor_client::db_models::MintItem;
 use harbor_client::db_models::transaction_item::{
     TransactionDirection, TransactionItem, TransactionItemKind,
 };
+use harbor_client::fedimint_core::config::FederationId;
 use iced::widget::{column, container, row, text, vertical_space};
 use iced::{Alignment, Element, Length};
 

--- a/harbor-ui/src/config.rs
+++ b/harbor-ui/src/config.rs
@@ -1,5 +1,4 @@
-use bitcoin::Network;
-use fedimint_core::anyhow;
+use harbor_client::bitcoin::Network;
 use harbor_client::data_dir;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;

--- a/harbor-ui/src/main.rs
+++ b/harbor-ui/src/main.rs
@@ -2,15 +2,15 @@ use crate::bridge::run_core;
 use crate::components::focus_input_id;
 use crate::components::{Toast, ToastManager, ToastStatus};
 use crate::config::{Config, write_config};
-use bitcoin::{Address, Network};
-use cdk::mint_url::MintUrl;
 use components::{MUTINY_GREEN, MUTINY_RED};
-use fedimint_core::Amount;
-use fedimint_core::core::ModuleKind;
-use fedimint_core::invite_code::InviteCode;
-use fedimint_ln_common::lightning_invoice::Bolt11Invoice;
+use harbor_client::Bolt11Invoice;
+use harbor_client::bitcoin::{Address, Network};
+use harbor_client::cdk::mint_url::MintUrl;
 use harbor_client::db_models::MintItem;
 use harbor_client::db_models::transaction_item::TransactionItem;
+use harbor_client::fedimint_core::Amount;
+use harbor_client::fedimint_core::core::ModuleKind;
+use harbor_client::fedimint_core::invite_code::InviteCode;
 use harbor_client::lightning_address::parse_lnurl;
 use harbor_client::{
     CoreUIMsg, CoreUIMsgPacket, MintIdentifier, ReceiveSuccessMsg, SendSuccessMsg, UICoreMsg,

--- a/harbor-ui/src/routes/settings.rs
+++ b/harbor-ui/src/routes/settings.rs
@@ -1,4 +1,4 @@
-use bitcoin::Network;
+use harbor_client::bitcoin::Network;
 use iced::widget::{column, pick_list, text};
 use iced::{Element, Length, Padding};
 


### PR DESCRIPTION
Makes it so any important bitcoin deps are either re-exported from the client lib, and any other extra deps that are shared are in the workspace. This way it should be easier to manage updating deps and not having conflicting versions.