### PR TITLE
add header to make it compatible with cdk-mintd based mints

### DIFF
--- a/harbor-client/src/http.rs
+++ b/harbor-client/src/http.rs
@@ -485,6 +485,7 @@ fn build_post_request<P: Serialize + Sized>(
     let mut builder = Request::builder()
         .uri(uri_str)
         .header("User-Agent", USER_AGENT)
+        .header("Content-Type", "application/json")
         .method("POST");
 
     // Only set Host header if we're not using an absolute URL


### PR DESCRIPTION
It fails to add cdk-mintd based mints when using Tor.

> [ERROR] HTTP request failed
Status: 415 Unsupported Media Type
Response body: Expected request with `Content-Type: application/json`

application/json is necessary in order to make it compatible with cdk-mintd.
