### PR TITLE
fix: circular spinner no longer skips

### DIFF
--- a/harbor-ui/src/components/spinner.rs
+++ b/harbor-ui/src/components/spinner.rs
@@ -144,16 +144,14 @@ impl Animation {
                 rotation: rotation.wrapping_add(additional_rotation),
                 last: now,
             },
-            Self::Contracting { rotation, .. } => {
-                Self::Expanding {
-                    start: now,
-                    progress: 0.0,
-                    rotation: rotation.wrapping_add(BASE_ROTATION_SPEED.wrapping_add(
-                        (f64::from(WRAP_ANGLE / (2.0 * Radians::PI)) * f64::MAX) as u32,
-                    )),
-                    last: now,
-                }
-            }
+            Self::Contracting { rotation, .. } => Self::Expanding {
+                start: now,
+                progress: 0.0,
+                rotation: rotation.wrapping_add(BASE_ROTATION_SPEED.wrapping_add(
+                    (f64::from(WRAP_ANGLE / (2.0 * Radians::PI)) * u32::MAX as f64) as u32,
+                )),
+                last: now,
+            },
         }
     }
 


### PR DESCRIPTION
All that I did here is changing `f64::MAX` to `u32::MAX as f64`. The rest of the diffs are just rust auto-formatting.

For details on why this fixes the issue, see this PR where I fixed the iced demo that had the same issue: https://github.com/iced-rs/iced/pull/2617