### PR TITLE
fix: make shadows transparent

### DIFF
--- a/harbor-ui/src/components/confirm_modal.rs
+++ b/harbor-ui/src/components/confirm_modal.rs
@@ -54,9 +54,9 @@ pub fn confirm_modal<'a>(
             text_color: Some(theme.palette().text),
             border: light_container_style(theme).border,
             shadow: Shadow {
-                color: Color::from_rgba8(0, 0, 0, 0.5),
-                offset: Vector::new(4.0, 4.0),
-                blur_radius: 8.0,
+                color: Color::TRANSPARENT,
+                offset: Vector::ZERO,
+                blur_radius: 0.0,
             },
         });
 
@@ -140,9 +140,9 @@ pub fn basic_modal<'a>(
                 text_color: Some(theme.palette().text),
                 border: light_container_style(theme).border,
                 shadow: Shadow {
-                    color: Color::from_rgba8(0, 0, 0, 0.5),
-                    offset: Vector::new(4.0, 4.0),
-                    blur_radius: 8.0,
+                    color: Color::TRANSPARENT,
+                    offset: Vector::ZERO,
+                    blur_radius: 0.0,
                 },
             });
 

--- a/harbor-ui/src/components/toast.rs
+++ b/harbor-ui/src/components/toast.rs
@@ -475,9 +475,9 @@ fn styled(background: Color, border: Color) -> container::Style {
             radius: (4.).into(),
         },
         shadow: Shadow {
-            color: Color::from_rgba8(0, 0, 0, 0.25),
-            offset: Vector::new(-2., -2.),
-            blur_radius: 4.,
+            color: Color::TRANSPARENT,
+            offset: Vector::ZERO,
+            blur_radius: 0.0,
         },
     }
 }


### PR DESCRIPTION
Currently, the usage of iced shadows are all partially-transparent black, but the background is set to be dark, so the shadow is practically invisible. Let's just set it to be transparent.