### PR TITLE
refactor: add strong typing to AddMint and PeekMint UI messages

### DIFF
--- a/harbor-client/src/lib.rs
+++ b/harbor-client/src/lib.rs
@@ -127,6 +127,26 @@ impl MintIdentifier {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum MintConnectionInfo {
+    Cashu(MintUrl),
+    Fedimint(InviteCode),
+}
+
+impl FromStr for MintConnectionInfo {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(url) = MintUrl::from_str(s) {
+            Ok(Self::Cashu(url))
+        } else if let Ok(invite_code) = InviteCode::from_str(s) {
+            Ok(Self::Fedimint(invite_code))
+        } else {
+            Err(anyhow::anyhow!("Invalid mint connection info: {}", s))
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct UICoreMsgPacket {
     pub id: Uuid,

--- a/harbor-ui/src/routes/mints.rs
+++ b/harbor-ui/src/routes/mints.rs
@@ -1,3 +1,6 @@
+use std::str::FromStr;
+
+use harbor_client::MintConnectionInfo;
 use iced::Element;
 use iced::widget::{column, row};
 
@@ -56,6 +59,8 @@ fn mints_list(harbor: &HarborWallet) -> Element<Message> {
 fn mints_add(harbor: &HarborWallet) -> Element<Message> {
     let header = h_header("Add Mint", "Add a new mint to your wallet.");
 
+    let mint_connection_info = MintConnectionInfo::from_str(&harbor.mint_invite_code_str).ok();
+
     let column = match &harbor.peek_federation_item {
         None => {
             let mint_input = h_input(InputArgs {
@@ -71,7 +76,7 @@ fn mints_add(harbor: &HarborWallet) -> Element<Message> {
                 SvgIcon::Eye,
                 harbor.peek_status == PeekStatus::Peeking,
             )
-            .on_press(Message::PeekMint(harbor.mint_invite_code_str.clone()));
+            .on_press_maybe(mint_connection_info.map(Message::PeekMint));
 
             let mut peek_column = column![mint_input, peek_mint_button].spacing(16);
 
@@ -91,7 +96,7 @@ fn mints_add(harbor: &HarborWallet) -> Element<Message> {
             let is_joining = harbor.add_federation_status == AddFederationStatus::Adding;
 
             let add_mint_button = h_button("Join Mint", SvgIcon::Plus, is_joining)
-                .on_press(Message::AddMint(harbor.mint_invite_code_str.clone()));
+                .on_press_maybe(mint_connection_info.map(Message::AddMint));
 
             let start_over_button = h_button("Start Over", SvgIcon::Restart, false)
                 .on_press(Message::CancelAddFederation);


### PR DESCRIPTION
Change the type within `Message::AddMint` and `Message::PeekMint` from `String` to a new `MintConnectionInfo` type, which is an enum containing either a `MintUrl` or `InviteCode`. This forces the parsing of connection strings to be moved from the message _processing_ code to the message _creation_ code. This has two positive effects:

* Removes the need to handle un-parseable strings in the message processing code (see the removal of the "Can't add mint" and "Can't preview mint" toasts)
* Forces the "Preview" and "Join Mint" buttons to use `.on_press_maybe()`, which disables the buttons unless a valid `MintConnectionInfo` can be parsed

Essentially, rather than allowing for the "Preview" and "Join Mint" buttons to be pressed at any time, but presenting error toasts if pressed with an unparseable value, we now disable these buttons from even being pressed unless a parseable value is entered