### PR TITLE
refactor: add strong typing to Send UI message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4068,6 +4068,7 @@ dependencies = [
  "harbor-client",
  "iced",
  "keyring-lib",
+ "lnurl-rs",
  "log",
  "lyon_algorithms",
  "opener",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 
 [workspace.dependencies]
 chrono = "0.4.38"
+lnurl-rs = { version = "0.9.0", default-features = false }
 log = "0.4"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"

--- a/harbor-client/Cargo.toml
+++ b/harbor-client/Cargo.toml
@@ -48,7 +48,7 @@ fedimint-lnv2-client = "0.7.1"
 
 # BEGIN BLOCK OF KEEP IN SYNC WITH FEDIMINT'S VERSION
 arti-client = { version = "0.20.0", default-features = false, features = ["tokio", "rustls"], package = "fedimint-arti-client" }
-lnurl-rs = { version = "0.9.0", default-features = false }
+lnurl-rs = { workspace = true }
 hyper = { version = "1.6.0", default-features = false, features = ["client", "http1"] }
 hyper-rustls = { version = "0.27.3", default-features = false }
 hyper-util = { version = "0.1.3", default-features = false, features = ["client", "client-legacy", "tokio"] }

--- a/harbor-ui/Cargo.toml
+++ b/harbor-ui/Cargo.toml
@@ -24,3 +24,4 @@ opener = { version = "0.7.2", features = ["reveal"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 keyring-lib = "1.0.2"
+lnurl-rs = { workspace = true }


### PR DESCRIPTION
Change the type within `Message::Send` from `String` to a new `SendDestination` type, which is an enum containing either a `Bolt11Invoice`, `LnUrl`, or `bitcoin::Address`. This forces the parsing of connection strings to be moved from the message _processing_ code to the message _creation_ code. This has two positive effects:

* Removes the need to handle un-parseable strings in the message processing code (see the removal of the "Invalid invoice or address" toast)
* Forces the "Send" button to use `.on_press_maybe()`, which disables the button unless a valid `SendDestination` can be parsed

Essentially, rather than allowing for the "Send" button to be pressed at any time, but presenting error toasts if pressed with an unparseable value, we now disable this button from even being pressed unless a parseable value is entered